### PR TITLE
Fix Vue DevTools loading

### DIFF
--- a/desktop-app/src/main/extensions/index.ts
+++ b/desktop-app/src/main/extensions/index.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+import fs from 'fs';
+import { session, app } from 'electron';
+
+export const loadVueDevTools = async (): Promise<void> => {
+  const extensionPath = path.resolve(app.getAppPath(), '..', 'extensions', 'vue-devtools');
+  if (!fs.existsSync(extensionPath)) {
+    console.warn(`[extensions] Vue DevTools not found at ${extensionPath}`);
+    return;
+  }
+  try {
+    await session.defaultSession.loadExtension(extensionPath, { allowFileAccess: true });
+    console.log(`[extensions] Vue DevTools loaded from ${extensionPath}`);
+  } catch (err) {
+    console.error(`[extensions] Failed to load Vue DevTools from ${extensionPath}`, err);
+  }
+};

--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -32,6 +32,7 @@ import { initHttpBasicAuthHandlers } from './http-basic-auth';
 import { initAppMetaHandlers } from './app-meta';
 import { openUrl } from './protocol-handler';
 import { AppUpdater } from './app-updater';
+import { loadVueDevTools } from './extensions';
 
 let windowShownOnOpen = false;
 
@@ -83,7 +84,7 @@ const installExtensions = async () => {
     'MOBX_DEVTOOLS',
     'APOLLO_DEVELOPER_TOOLS',
   ];
-
+  await loadVueDevTools();
   return installer
     .default(
       extensions.map((name) => installer[name]),


### PR DESCRIPTION
## Summary
- add helper to load unpacked Vue DevTools
- call the loader during extension installation

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6855050f84fc832085e48b20d37d514f